### PR TITLE
molecule: Use latest Ansible release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
     strategy:
       matrix:
         distro:
-          - 'rockylinux8'
           - 'rockylinux9'
           - 'fedora40'
           - 'fedora41'

--- a/molecule/docker/requirements.txt
+++ b/molecule/docker/requirements.txt
@@ -1,4 +1,4 @@
-ansible-core==2.16.7
+ansible-core
 docker
 molecule
 molecule-plugins[docker]

--- a/molecule/podman/requirements.txt
+++ b/molecule/podman/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core==2.16.7
+ansible-core
 molecule
 molecule-plugins[podman]


### PR DESCRIPTION
Remove Rocky Linux 8 from the test matrix as there are some weird Python errors during facts gathering. 